### PR TITLE
Add tests for Container Control

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+
+from fastapi.testclient import TestClient
+
+
+def load_core(config: Dict[str, str]) -> tuple[TestClient, object]:
+    cfg_path = Path(config["config_path"])
+    os.environ["CCC_CONFIG_FILE"] = str(cfg_path)
+    if "container_control_core" in sys.modules:
+        del sys.modules["container_control_core"]
+    core = importlib.import_module("container_control_core")
+    client = TestClient(core.app)
+    return client, core

--- a/tests/dummy_adapter.py
+++ b/tests/dummy_adapter.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+from app_adapter import ApplicationAdapter
+
+
+class DummyAdapter(ApplicationAdapter):
+    def __init__(self, static_cfg: Dict[str, Any] | None = None) -> None:
+        super().__init__(static_cfg)
+        self.started_payload: Dict[str, Any] | None = None
+        self.stopped = False
+        self.updated_payload: Dict[str, Any] | None = None
+        self.ensure_user_cmd: List[str] | None = None
+
+    def start(self, start_payload: Dict[str, Any], *, ensure_user) -> Any:
+        self.started_payload = start_payload
+        # simulate using the ensure_user helper
+        self.ensure_user_cmd = ensure_user(["dummy"])
+        return "handle"
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def update(self, update_payload: Dict[str, Any]) -> bool:
+        self.updated_payload = update_payload
+        return update_payload.get("ok", False)
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return {"running": not self.stopped}
+
+    def prometheus_metrics(self) -> List[str]:
+        return ["dummy_metric 1"]
+
+    def pre_start_hooks(self, start_payload: Dict[str, Any]) -> None:
+        # simulate privileged setup delay
+        time.sleep(0.01)
+
+    def post_stop_hooks(self) -> None:
+        time.sleep(0.01)
+
+
+class NoUpdateAdapter(DummyAdapter):
+    def update(self, update_payload: Dict[str, Any]) -> bool:
+        raise NotImplementedError

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.dummy_adapter import DummyAdapter, NoUpdateAdapter
+from tests.conftest import load_core
+
+
+def make_config(tmp_path: Path, adapter_cls: str, run_as_user: str | None = None) -> Path:
+    cfg = {
+        "adapter": {
+            "class": adapter_cls,
+            "primary_payload_key": "payload",
+            "run_as_user": run_as_user,
+        }
+    }
+    path = tmp_path / "config.yaml"
+    import ruamel.yaml
+    ruamel.yaml.YAML().dump(cfg, path.open("w"))
+    return path
+
+
+def test_start_stop_cycle(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
+    client, core = load_core({"config_path": str(cfg_path)})
+
+    resp = client.post("/api/start", json={"payload": 1})
+    assert resp.status_code == 200
+    time.sleep(0.05)
+    assert core.state["app_status"] == "running"
+
+    resp = client.post("/api/stop", json={})
+    assert resp.status_code == 200
+    time.sleep(0.05)
+    assert core.state["app_status"] == "stopped"
+    assert isinstance(core.adapter, DummyAdapter)
+    assert core.adapter.stopped
+
+
+def test_start_requires_key(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
+    client, _ = load_core({"config_path": str(cfg_path)})
+
+    resp = client.post("/api/start", json={})
+    assert resp.status_code == 400
+
+
+def test_update_paths(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
+    client, core = load_core({"config_path": str(cfg_path)})
+
+    client.post("/api/start", json={"payload": 1})
+    time.sleep(0.05)
+
+    resp = client.post("/api/update", json={"ok": True})
+    assert resp.status_code == 200
+    assert core.adapter.updated_payload == {"ok": True}
+
+    resp = client.post("/api/update", json={"ok": False})
+    assert resp.status_code == 409
+
+
+def test_update_not_supported(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.NoUpdateAdapter")
+    client, _ = load_core({"config_path": str(cfg_path)})
+
+    client.post("/api/start", json={"payload": 1})
+    time.sleep(0.05)
+    resp = client.post("/api/update", json={"x": 1})
+    assert resp.status_code == 409
+
+
+def test_metrics_and_prometheus(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
+    client, _ = load_core({"config_path": str(cfg_path)})
+
+    client.post("/api/start", json={"payload": 1})
+    time.sleep(0.05)
+
+    resp = client.get("/api/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "timestamp" in data
+    assert "metrics" in data
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "container_cpu_percent" in resp.text
+    assert "dummy_metric" in resp.text
+
+
+def test_health_endpoint(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
+    client, _ = load_core({"config_path": str(cfg_path)})
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_run_as_user(tmp_path):
+    cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter", "appuser")
+    client, core = load_core({"config_path": str(cfg_path)})
+
+    client.post("/api/start", json={"payload": 1})
+    time.sleep(0.05)
+    assert core.adapter.ensure_user_cmd[:4] == ["sudo", "-E", "-u", "appuser"]


### PR DESCRIPTION
## Summary
- create DummyAdapter and NoUpdateAdapter for testing
- add pytest fixtures and helper to load CCC
- cover all API endpoints and run-as-user behavior

## Testing
- `python -m py_compile tests/dummy_adapter.py tests/conftest.py tests/test_core.py tests/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684dc82695588320981893e1a84bcda7