### PR TITLE
Add edge case tests

### DIFF
--- a/tests/dummy_adapter.py
+++ b/tests/dummy_adapter.py
@@ -44,3 +44,8 @@ class DummyAdapter(ApplicationAdapter):
 class NoUpdateAdapter(DummyAdapter):
     def update(self, update_payload: Dict[str, Any]) -> bool:
         raise NotImplementedError
+
+
+class ErrorUpdateAdapter(DummyAdapter):
+    def update(self, update_payload: Dict[str, Any]) -> bool:
+        raise ValueError("boom")


### PR DESCRIPTION
## Summary
- extend dummy adapter with `ErrorUpdateAdapter`
- add tests for edge cases including restart, update when not running and error cases

## Testing
- `python -m py_compile tests/dummy_adapter.py`
- `python -m py_compile tests/test_core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684dcfefc8708320a5292d3fd4ee44d2