### PR TITLE
Add bootstrap script and quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ This repository explains how to integrate any containerised workload with Showru
 
 1. [Concept](#concept)
 2. [Files You Care About](#files-you-care-about)
-3. [Building an Adapter](#building-an-adapter)
-4. [Configuration (`config.yaml`)](#configuration-configyaml)
-5. [Dockerfile Template](#dockerfile-template)
-6. [API Reference](#api-reference)
-7. [Operational Tips](#operational-tips)
+3. [Quickstart (`bootstrap.py`)](#quickstart-bootstrappy)
+4. [Building an Adapter](#building-an-adapter)
+5. [Configuration (`config.yaml`)](#configuration-configyaml)
+6. [Dockerfile Template](#dockerfile-template)
+7. [API Reference](#api-reference)
+8. [Operational Tips](#operational-tips)
 
 ---
 
@@ -53,6 +54,19 @@ Your real workload (async code, binary, …)
 | `my_adapter.py`             | No               | Your shim – implements the contract.                                |
 | `config.yaml`               | No               | Declares which adapter to load & options.                           |
 | `Dockerfile`                | No               | Builds the image using the template below.                          |
+
+---
+
+## Quickstart (`bootstrap.py`)
+
+Run the helper script to copy the core files into your project:
+
+```bash
+python bootstrap.py /path/to/your/app
+```
+
+This creates `container_control_core.py`, `app_adapter.py`, `config.yaml`,
+and a skeleton adapter.  A Dockerfile is also copied if none exists.
 
 ---
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,61 @@
+"""Scaffold Container Control integration in a target directory."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+import textwrap
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Copy CCC files and create an adapter stub"
+    )
+    parser.add_argument(
+        "target", help="Destination directory for the scaffold"
+    )
+    parser.add_argument(
+        "--adapter", default="my_adapter.py",
+        help="Adapter file name to create if missing"
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).parent
+    dest = Path(args.target).resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for fname in ("container_control_core.py", "app_adapter.py"):
+        shutil.copy(root / fname, dest / fname)
+
+    if not (dest / "config.yaml").exists():
+        shutil.copy(root / "config.yaml.example", dest / "config.yaml")
+
+    if not (dest / "Dockerfile").exists():
+        shutil.copy(root / "Dockerfile.example", dest / "Dockerfile")
+
+    adapter_path = dest / args.adapter
+    if not adapter_path.exists():
+        stub = textwrap.dedent(
+            """
+            from app_adapter import ApplicationAdapter
+
+
+            class MyAdapter(ApplicationAdapter):
+                def start(self, payload, *, ensure_user):
+                    raise NotImplementedError
+
+                def stop(self):
+                    raise NotImplementedError
+
+                def get_metrics(self):
+                    return {}
+            """
+        )
+        adapter_path.write_text(stub)
+
+    print(f"Container Control scaffold written to {dest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `bootstrap.py` helper script
- document quickstart using the new script

## Testing
- `python -m py_compile bootstrap.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684dd9bada9c8320970b6a42ceba5b35