### PR TITLE
Allow live bandwidth updates via /api/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ CMD ["python", "-m", "uvicorn", "container_control_core:app", "--host", "0.0.0.0
 | Method | Path          | Description                                                                                         |
 |--------|---------------|-----------------------------------------------------------------------------------------------------|
 | `POST` | `/api/start`  | Start the workload (or restart if running). Payload must include the key named in `config.yaml`.   |
-| `POST` | `/api/update` | Live config tweak. Returns 200 on success, 409 if unsupported, 400 if the app is not running.       |
+| `POST` | `/api/update` | Live config tweak (e.g., traffic control) without restart. Returns 200 on success, 409 if unsupported, 400 if the app is not running. |
 | `POST` | `/api/stop`   | Graceful stop.                                                                                      |
 | `GET`  | `/api/metrics`| JSON with container + adapter metrics.                                                              |
 | `GET`  | `/metrics`    | Prometheus exposition.                                                                              |

--- a/container_control_core.py
+++ b/container_control_core.py
@@ -323,15 +323,25 @@ async def api_update(body: UpdateBody):
     payload = body.root
     if state["app_status"] != "running":
         raise HTTPException(400, "Application not running, cannot update.")
+    tc_keys = [TC_CFG.get("bandwidth_mbps_key"), TC_CFG.get("latency_ms_key")]
+    tc_requested = TC_CFG.get("enabled") and any(
+        k and k in payload for k in tc_keys
+    )
+    if tc_requested:
+        _apply_traffic_control(payload)
 
     try:
-        # The adapter is always responsible for handling updates.
+        # The adapter is responsible for handling non-TC updates.
         updated = adapter.update(payload)
-        if updated:
+        if updated or tc_requested:
             return {"message": "update applied"}
         raise HTTPException(409, "adapter declined update")
     except NotImplementedError:
+        if tc_requested:
+            return {"message": "update applied"}
         raise HTTPException(409, "live-update not supported by this adapter") from None
+    except HTTPException:
+        raise
     except Exception as exc:
         log.exception("adapter.update failed")
         raise HTTPException(500, str(exc))
@@ -340,7 +350,7 @@ async def api_update(body: UpdateBody):
 @app.post("/api/stop")
 async def api_stop(_: StopBody):
     if state["app_status"] != "running":
-        return {"message": "application not running, nothing to stop"}
+        return {"message": "nothing to stop"}
     _thread(_stop)
     return {"message": "stop initiated"}
 
@@ -390,6 +400,7 @@ async def api_metrics():
 
     # --- Adapter-provided metrics ---
     base_metrics["adapter_metrics"] = adapter.get_metrics() or {}
+    base_metrics["metrics"] = base_metrics["adapter_metrics"]
 
     return JSONResponse(base_metrics)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,16 @@ def make_config(tmp_path: Path, adapter_cls: str, run_as_user: str | None = None
     return path
 
 
+class TCOnlyAdapter(NoUpdateAdapter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_calls = 0
+
+    def start(self, start_payload, *, ensure_user):
+        self.start_calls += 1
+        return super().start(start_payload, ensure_user=ensure_user)
+
+
 def test_start_stop_cycle(tmp_path):
     cfg_path = make_config(tmp_path, "tests.dummy_adapter.DummyAdapter")
     client, core = load_core({"config_path": str(cfg_path)})
@@ -72,6 +82,47 @@ def test_update_not_supported(tmp_path):
     time.sleep(0.05)
     resp = client.post("/api/update", json={"x": 1})
     assert resp.status_code == 409
+
+
+def test_tc_update_without_restart(tmp_path, monkeypatch):
+    cfg = {
+        "adapter": {
+            "class": "tests.test_core.TCOnlyAdapter",
+            "primary_payload_key": "payload",
+        },
+        "traffic_control": {
+            "enabled": True,
+            "interface": "eth0",
+            "bandwidth_mbps_key": "bandwidth",
+            "default_bandwidth_mbps": 50,
+        },
+    }
+    path = tmp_path / "config.yaml"
+    import ruamel.yaml
+    ruamel.yaml.YAML().dump(cfg, path.open("w"))
+
+    client, core = load_core({"config_path": str(path)})
+
+    tc_calls: list[dict] = []
+
+    def fake_tc(payload):
+        tc_calls.append(payload.copy())
+
+    monkeypatch.setattr(core, "_apply_traffic_control", fake_tc)
+
+    client.post("/api/start", json={"payload": 1, "bandwidth": 10})
+    time.sleep(0.05)
+    adapter = core.adapter
+    assert isinstance(adapter, TCOnlyAdapter)
+    assert adapter.start_calls == 1
+    assert len(tc_calls) == 1
+
+    resp = client.post("/api/update", json={"bandwidth": 20})
+    assert resp.status_code == 200
+    time.sleep(0.05)
+    assert adapter.start_calls == 1
+    assert len(tc_calls) == 2
+    assert tc_calls[-1]["bandwidth"] == 20
 
 
 def test_metrics_and_prometheus(tmp_path):


### PR DESCRIPTION
## Summary
- Apply traffic control changes during `/api/update` without restarting the app
- Report adapter metrics under both `metrics` and `adapter_metrics`
- Standardize `/api/stop` message and document `/api/update` behavior
- Add regression test ensuring bandwidth updates don't trigger restart

## Testing
- `python -m py_compile container_control_core.py tests/test_core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d84a165608320bf91d36af51f2058