### PR TITLE
Prepare container-control 1.1.0 for PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 1.1.0 - 2025-09-16
+
+### Added
+- Published packaging metadata for the `container-control` distribution.
+  This includes an explicit README content type, keywords, and project URLs.
+- Exposed the installed package version through `container_control.__version__`.
+- Documented the release and packaging process for the first public PyPI
+  build.
+- Added a distributable `LICENSE` artifact for the proprietary release.
+
+### Changed
+- Bumped the project version to `1.1.0` for the PyPI release track.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,4 @@
+Copyright (c) 2025 Showrunner.
+All rights reserved. This software is provided under a proprietary license.
+Unauthorized copying, distribution, or modification of this software is strictly
+prohibited without prior written permission from the copyright holder.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **One immutable core + lightweight adapter + optional services = zero boilerplate.**
 
-This repository explains how to integrate any containerised workload with Showrunner using the **Container Control Core (CCC) v2.0**.
+This repository explains how to integrate any containerised workload with Showrunner using the **Container Control Core (CCC) v1.1**.
 
 The core now provides optional built-in services for process management, metrics collection, traffic control, and privileged operations - reducing the complexity of your adapters even further.
 
@@ -28,7 +28,7 @@ The core now provides optional built-in services for process management, metrics
 ```
 (root, FastAPI)
 ┌──────────────────────────────────────────┐
-│ container_control_core.py (v2.0)         │
+│ container_control_core.py (v1.1)         │
 │ • HTTP API (/api/*, /metrics)            │
 │ • lifecycle / state / signals            │
 │ • container-level metrics                │
@@ -44,13 +44,13 @@ The core now provides optional built-in services for process management, metrics
  app_adapter.py  ← common interface
               │ subclassed by you
               ▼
- my_adapter.py  ← 5‑30 LOC typical (v2.0)
+ my_adapter.py  ← 5‑30 LOC typical (v1.1)
               │ calls (if needed)
               ▼
 Your real workload (async code, binary, …)
 ```
 
-*All containers share the **exact same** `container_control_core.py` v2.0; only `my_adapter.py` and `config.yaml` vary per application. The core's optional services can eliminate most boilerplate code.*
+*All containers share the **exact same** `container_control_core.py` v1.1; only `my_adapter.py` and `config.yaml` vary per application. The core's optional services can eliminate most boilerplate code.*
 
 ---
 
@@ -68,7 +68,7 @@ Your real workload (async code, binary, …)
 
 ## Core Services
 
-Container Control Core v2.0 includes optional built-in services that can handle common container operations, reducing the complexity of your adapters:
+Container Control Core v1.1 includes optional built-in services that can handle common container operations, reducing the complexity of your adapters:
 
 ### Process Management Service
 - **Purpose**: Let the core manage your application process lifecycle
@@ -139,7 +139,7 @@ write_scaffold("/path/to/your/app")
 
 ## Building an Adapter
 
-Copy `app_adapter.py` into your repo, then create `my_adapter.py`. With v2.0's core services, adapters can be much simpler:
+Copy `app_adapter.py` into your repo, then create `my_adapter.py`. With v1.1's core services, adapters can be much simpler:
 
 ### Simple Adapter (using core services)
 ```python
@@ -197,7 +197,7 @@ class MyAdapter(ApplicationAdapter):
         )
 ```
 
-**v2.0 adapter size**: Often < 15 lines when using core services!
+**v1.1 adapter size**: Often < 15 lines when using core services!
 **Traditional adapter size**: 20-40 lines when managing everything manually.
 
 ---
@@ -336,8 +336,18 @@ All timestamps are UTC ISO-8601 (`YYYY-MM-DDTHH:MM:SS.mmmmmmZ`).
 
 ### Upgrading
 - **Core updates**: Replace `container_control_core.py` in the image
-- **Adapter compatibility**: v2.0 is backward compatible with v1.x adapters
+- **Adapter compatibility**: v1.1 is backward compatible with v1.x adapters
 - **New services**: Add optional service configs without breaking existing deployments
+
+## Publishing to PyPI
+
+1. Update `CHANGELOG.md` and bump `pyproject.toml` / `container_control`
+   version information.
+2. Run the full test suite with `pytest` to ensure the core behaviour is
+   unchanged.
+3. Remove any previous build artefacts (`rm -rf dist build *.egg-info`) and
+   build fresh wheels and source archives using `python -m build`.
+4. Upload the contents of `dist/` with `twine upload dist/*`.
 
 Happy Showrunning! :clapper:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Robust Example Configuration for Container Control Core v2.0
+# Robust Example Configuration for Container Control Core v1.1
 # -----------------------------------------------------------------------------
 
 # --- Adapter Configuration (Required) ---

--- a/container_control/__init__.py
+++ b/container_control/__init__.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 from app_adapter import ApplicationAdapter
 
 from .scaffold import render_adapter_stub, scaffold_files, write_scaffold
+
+try:
+    __version__ = version("container-control")
+except PackageNotFoundError:  # pragma: no cover - fallback during local dev
+    __version__ = "1.1.0"
 
 __all__ = [
     "ApplicationAdapter",
     "render_adapter_stub",
     "scaffold_files",
     "write_scaffold",
+    "__version__",
 ]

--- a/container_control/templates/config.yaml.example
+++ b/container_control/templates/config.yaml.example
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Robust Example Configuration for Container Control Core v2.0
+# Robust Example Configuration for Container Control Core v1.1
 # -----------------------------------------------------------------------------
 
 # --- Adapter Configuration (Required) ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "container-control"
-version = "0.1.0"
+version = "1.1.0"
 description = "Container Control Core for Showrunner"
-readme = "README.md"
+readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
-license = {text = "Proprietary"}
+license = "LicenseRef-Proprietary"
+license-files = ["LICENSE"]
 authors = [
     {name = "Showrunner Team"},
 ]
+keywords = ["containers", "fastapi", "scaffolding", "showrunner"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Framework :: FastAPI",
-    "License :: Other/Proprietary License",
     "Operating System :: POSIX :: Linux",
     "Topic :: System :: Systems Administration",
 ]
@@ -37,9 +38,14 @@ test = [
 [project.scripts]
 container-control-bootstrap = "bootstrap:main"
 
+[project.urls]
+Documentation = "https://github.com/showrunner-dev/container-control#readme"
+Repository = "https://github.com/showrunner-dev/container-control"
+Issues = "https://github.com/showrunner-dev/container-control/issues"
+
 [tool.setuptools]
 include-package-data = true
-packages = ["container_control"]
+packages = ["container_control", "container_control.templates"]
 py-modules = ["container_control_core", "app_adapter", "bootstrap"]
 
 [tool.setuptools.package-data]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -252,7 +252,7 @@ def test_core_services_config(tmp_path):
 
 
 def test_new_adapter_hooks(tmp_path):
-    """Test that new v2.0 adapter hooks are called"""
+    """Test that new v1.1 adapter hooks are called"""
     from tests.dummy_adapter import DummyAdapter
 
     # Create a test adapter with the new hooks

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import container_control
+
+
+def test_package_version_matches_pyproject() -> None:
+    """Ensure the exposed version matches the published metadata."""
+
+    pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"(?P<version>[^\"]+)"',
+                      pyproject_text, re.MULTILINE)
+    assert match is not None, "version field missing from pyproject"
+    assert container_control.__version__ == match.group("version")


### PR DESCRIPTION
## Summary
- bump the project metadata to 1.1.0 with keywords, SPDX-style license details, package discovery fixes, and repository URLs
- expose `container_control.__version__` and add a unit test that checks it against the declared project version
- refresh the README, configuration templates, changelog, and license so the documentation matches the 1.1.0 PyPI release and documents the publishing workflow

## Testing
- python -m py_compile container_control/__init__.py tests/test_core.py tests/test_package_metadata.py
- pytest
- python -m build

------
https://chatgpt.com/codex/tasks/task_b_68c9516c41a08320a6a3ddaad7173380