### PR TITLE
Add manual PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Version to publish (must match pyproject.toml)'
+        required: true
+
+jobs:
+  build-and-publish:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/container-control/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Verify requested version
+        run: |
+          expected="${{ github.event.inputs.release-version }}"
+          actual=$(python -c "import tomllib;\nwith open('pyproject.toml', 'rb') as fh:\n    print(tomllib.load(fh)['project']['version'])")
+          if [ "$expected" != "$actual" ]; then
+            echo "Requested version '$expected' does not match pyproject.toml version '$actual'." >&2
+            exit 1
+          fi
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The core now provides optional built-in services for process management, metrics
 9. [Dockerfile Template](#dockerfile-template)
 10. [API Reference](#api-reference)
 11. [Operational Tips](#operational-tips)
+12. [Publishing to PyPI](#publishing-to-pypi)
 
 ---
 
@@ -369,13 +370,35 @@ All timestamps are UTC ISO-8601 (`YYYY-MM-DDTHH:MM:SS.mmmmmmZ`).
 
 ## Publishing to PyPI
 
-1. Update `CHANGELOG.md` and bump `pyproject.toml` / `container_control`
-   version information.
-2. Run the full test suite with `pytest` to ensure the core behaviour is
-   unchanged.
-3. Remove any previous build artefacts (`rm -rf dist build *.egg-info`) and
-   build fresh wheels and source archives using `python -m build`.
-4. Upload the contents of `dist/` with `twine upload dist/*`.
+Container Control is published through the manual **Publish to PyPI**
+workflow (`.github/workflows/publish.yml`). The job uses PyPI's Trusted
+Publishers integration with GitHub OpenID Connect, so no long-lived API
+tokens are stored in the repository.
+
+### One-time setup
+
+1. In **Settings → Environments**, create an environment named `pypi` and set
+   the environment URL to <https://pypi.org/project/container-control/>.
+2. On PyPI, add a Trusted Publisher with the following values:
+   - **PyPI project name**: `container-control`
+   - **Owner**: `showrunner-dev`
+   - **Repository name**: `container-control`
+   - **Workflow name**: `publish.yml`
+   - **Environment name**: `pypi`
+3. (Optional) Require reviewers or branch protections on the `pypi`
+   environment before the workflow can deploy.
+
+No repository secrets or variables are required; PyPI issues a short-lived
+token to the workflow at runtime via OIDC.
+
+### Releasing
+
+1. Update `CHANGELOG.md` and bump the version in `pyproject.toml`.
+2. Run the test suite (`pytest`) to confirm behaviour before publishing.
+3. Trigger **Publish to PyPI** from the *Actions* tab and supply the version
+   from `pyproject.toml` when prompted.
+4. The workflow builds fresh distributions with `python -m build` and, after
+   the environment approval (if configured), uploads them to PyPI.
 
 Happy Showrunning! :clapper:
 


### PR DESCRIPTION
## Summary
- add a manually-triggered Publish to PyPI workflow that builds the project and deploys via PyPI Trusted Publishers/OIDC
- document the one-time environment setup and release process in the README, including the values required by the PyPI form

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68c97bd8be148320a8fb6a59c8b97cf4