### PR TITLE
Update project links for rdwr-taly

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ tokens are stored in the repository.
    the environment URL to <https://pypi.org/project/container-control/>.
 2. On PyPI, add a Trusted Publisher with the following values:
    - **PyPI project name**: `container-control`
-   - **Owner**: `showrunner-dev`
+   - **Owner**: `rdwr-taly`
    - **Repository name**: `container-control`
    - **Workflow name**: `publish.yml`
    - **Environment name**: `pypi`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ test = [
 container-control-bootstrap = "bootstrap:main"
 
 [project.urls]
-Documentation = "https://github.com/showrunner-dev/container-control#readme"
-Repository = "https://github.com/showrunner-dev/container-control"
-Issues = "https://github.com/showrunner-dev/container-control/issues"
+Documentation = "https://github.com/rdwr-taly/container-control#readme"
+Repository = "https://github.com/rdwr-taly/container-control"
+Issues = "https://github.com/rdwr-taly/container-control/issues"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- update the README to reference rdwr-taly as the PyPI trusted publisher owner
- point the project metadata URLs to the rdwr-taly GitHub repository

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68c9843f63548320a84abef38ecf8dba