### PR TITLE
Document package layout for code agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ Working inside a clone, install dependencies with `pip install -e .` so the
 `src/` directory is on the Python path. The automated test suite mirrors this
 layout by placing `src/` at the front of `sys.path`.
 
+### Code map for automation & code-reading agents
+
+Agents or humans inspecting the published wheel will see the same structure as
+the source tree above. The key modules and the responsibilities they cover are:
+
+| Module | What it provides | Typical consumers |
+| --- | --- | --- |
+| `container_control_core` | The FastAPI service. Hosts REST, Prometheus, optional process/metrics/traffic/privileged services. | Runtime containers only. The file ships verbatim so adapters can rely on a stable API. |
+| `app_adapter` | Abstract base class adapters must subclass. Documents lifecycle hooks such as `start`, `stop`, and `update`. | Adapter authors. Keep this file identical across services. |
+| `bootstrap` | CLI entry point `container-control-bootstrap`. Calls `write_scaffold()` to copy the canonical files into a target directory. | Developers who want to initialise a project or refresh the canonical files. |
+| `container_control/__init__.py` | Convenience exports so `from container_control import write_scaffold` works without drilling into submodules. Also exposes the installed version. | Library users and automation tools. |
+| `container_control/scaffold.py` | The implementation behind scaffolding helpers. Loads byte-for-byte copies of the canonical modules and resource templates. | CLI + advanced users needing programmatic access. |
+| `container_control/templates/` | Template assets for `config.yaml` and the Dockerfile example. | Scaffolding utilities. |
+
+When browsing the wheel contents you can therefore start with
+`container_control_core` to understand the runtime API and then follow imports
+into `app_adapter` to see the adapter contract. The remaining modules focus on
+setting up those two canonical files.
+
 ---
 
 ## Files You Care About

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ container-control-bootstrap = "bootstrap:main"
 Documentation = "https://github.com/rdwr-taly/container-control#readme"
 Repository = "https://github.com/rdwr-taly/container-control"
 Issues = "https://github.com/rdwr-taly/container-control/issues"
+Changelog = "https://github.com/rdwr-taly/container-control/blob/main/CHANGELOG.md"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/bootstrap.py
+++ b/src/bootstrap.py
@@ -1,4 +1,10 @@
-"""Scaffold Container Control integration in a target directory."""
+"""CLI entry point for generating Container Control scaffolds.
+
+The ``container-control-bootstrap`` console script resolves to :func:`main`. It
+exists primarily for developers who prefer a command line interface, whereas
+automation or unit tests usually call :func:`container_control.write_scaffold`
+directly.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +15,8 @@ from container_control.scaffold import ScaffoldError, write_scaffold
 
 
 def main() -> None:
+    """Parse CLI arguments and write the scaffold to disk."""
+
     parser = argparse.ArgumentParser(
         description="Copy CCC files and create an adapter stub",
     )

--- a/src/container_control/__init__.py
+++ b/src/container_control/__init__.py
@@ -1,4 +1,25 @@
-"""Public interface for the Container Control package."""
+"""High-level entry points for Container Control.
+
+This module deliberately re-exports the handful of symbols that adapter
+projects interact with most frequently so that automation agents (human or
+otherwise) can inspect the package and immediately discover how to bootstrap a
+container.
+
+`ApplicationAdapter`
+    Abstract base class that adapters must inherit from.  It documents the
+    lifecycle hooks exposed by :mod:`container_control_core`.
+`write_scaffold`
+    Copy the canonical core files, templates, and adapter stub into a target
+    directory.  This is the programmatic counterpart to the
+    ``container-control-bootstrap`` CLI.
+`scaffold_files` / `render_adapter_stub`
+    Lower level helpers that return the same assets without touching the file
+    system.
+
+The rest of the modules contained in the package build upon these re-exports.
+Keeping the public API surface centralised makes the PyPI distribution easier
+to audit and script against.
+"""
 
 from __future__ import annotations
 

--- a/src/container_control/scaffold.py
+++ b/src/container_control/scaffold.py
@@ -1,4 +1,11 @@
-"""Utilities for generating Container Control scaffolds."""
+"""Utilities for generating Container Control scaffolds.
+
+The functions in this module intentionally mirror the CLI behaviour provided by
+:mod:`bootstrap`.  They return byte content so that callers can choose whether
+to write to disk, embed the files inside another tool, or perform inspections
+during automated reviews.  This mirrors the layout and file contents that ship
+on PyPI.  No templating or mutation happens at runtime.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +14,12 @@ from importlib import resources as importlib_resources
 from pathlib import Path
 import textwrap
 from typing import Dict
+
+ScaffoldContents = Dict[str, bytes]
+"""Dictionary mapping filenames to their raw bytes in the scaffold."""
+
+WrittenFiles = Dict[str, Path]
+"""Dictionary mapping filenames to where they were written on disk."""
 
 _MODULE_TEMPLATES = {
     "container_control_core": "container_control_core.py",
@@ -43,6 +56,12 @@ class ScaffoldError(RuntimeError):
 
 
 def _load_module_bytes(module_name: str) -> bytes:
+    """Return the raw bytes of an importable module.
+
+    The helper keeps :mod:`container_control_core` and :mod:`app_adapter`
+    identical across every generated scaffold.  It copies their canonical
+    versions directly from the installed distribution.
+    """
     spec = importlib.util.find_spec(module_name)
     if spec is None or spec.origin is None or spec.loader is None:
         raise ScaffoldError(f"Unable to locate module '{module_name}'")
@@ -53,6 +72,7 @@ def _load_module_bytes(module_name: str) -> bytes:
 
 
 def _load_resource_bytes(resource_name: str) -> bytes:
+    """Return bytes from the package data templates directory."""
     try:
         resource = importlib_resources.files(
             _TEMPLATES_PACKAGE,
@@ -65,21 +85,34 @@ def _load_resource_bytes(resource_name: str) -> bytes:
 
 
 def render_adapter_stub() -> str:
-    """Return the default adapter stub as a string."""
+    """Return the default adapter stub as a string.
+
+    Useful for documentation tooling that wants to display the scaffold without
+    writing to disk.
+    """
 
     return _ADAPTER_STUB
 
 
-def scaffold_files(adapter_filename: str | None = "my_adapter.py") -> Dict[str, bytes]:
-    """Return the files that make up a default scaffold.
+def scaffold_files(
+    adapter_filename: str | None = "my_adapter.py",
+) -> ScaffoldContents:
+    """Return the byte representation of the default scaffold files.
 
     Parameters
     ----------
     adapter_filename:
         Name of the adapter stub file to include. Use ``None`` to skip it.
+
+    Returns
+    -------
+    dict
+        Mapping of filenames to bytes. The dictionary always includes the
+        canonical ``container_control_core.py`` and ``app_adapter.py`` modules
+        plus the config and Dockerfile templates. The adapter stub is optional.
     """
 
-    files: Dict[str, bytes] = {}
+    files: ScaffoldContents = {}
     for module_name, target_name in _MODULE_TEMPLATES.items():
         files[target_name] = _load_module_bytes(module_name)
     for dest_name, resource_name in _RESOURCE_TEMPLATES.items():
@@ -93,19 +126,29 @@ def write_scaffold(
     destination: Path | str,
     *,
     adapter_filename: str | None = "my_adapter.py",
-) -> Dict[str, Path]:
+) -> WrittenFiles:
     """Write the default scaffold into ``destination``.
 
-    Core modules are always overwritten. The config, Dockerfile, and adapter
-    stub are created only if the destination file does not already exist.
-    Returns a mapping of filenames to their on-disk paths for the files that
-    were written during this invocation.
+    Parameters
+    ----------
+    destination:
+        Directory that should receive the canonical files.
+    adapter_filename:
+        Optional filename for the adapter stub.
+        Passing ``None`` skips creating an adapter.
+
+    Returns
+    -------
+    dict
+        Files that were actually written in this invocation.  Core modules are
+        always replaced to guarantee parity with the PyPI release, whereas the
+        config, Dockerfile, and adapter stub respect any existing files.
     """
 
     dest_path = Path(destination)
     dest_path.mkdir(parents=True, exist_ok=True)
 
-    written: Dict[str, Path] = {}
+    written: WrittenFiles = {}
     files = scaffold_files(adapter_filename)
 
     for filename, content in files.items():


### PR DESCRIPTION
## Summary
- add a "code map" section to the README so humans and automation know which modules to inspect first
- expand the public module docstrings in `container_control.__init__`, `container_control.scaffold`, and the bootstrap CLI for clearer intent
- expose the changelog URL in the published package metadata for easier reference

## Testing
- python -m py_compile src/container_control/__init__.py
- python -m py_compile src/container_control/scaffold.py
- python -m py_compile src/bootstrap.py

------
https://chatgpt.com/codex/tasks/task_b_68c98689d6108320adb175fb5b53864b