### PR TITLE
Fix publish workflow version check command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Verify requested version
         run: |
           expected="${{ github.event.inputs.release-version }}"
-          actual=$(python -c "import tomllib;\nwith open('pyproject.toml', 'rb') as fh:\n    print(tomllib.load(fh)['project']['version'])")
+          actual=$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
           if [ "$expected" != "$actual" ]; then
             echo "Requested version '$expected' does not match pyproject.toml version '$actual'." >&2
             exit 1


### PR DESCRIPTION
## Summary
- fix the Python version verification command in the publish workflow to avoid shell escape issues

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_b_68c989c0035c8320b313db49bff8af98